### PR TITLE
[TASK] Release Drafter 用ラベルセットアップスクリプトの作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,24 @@ chmod +x scripts/rename-project.sh
 
 実行後、Android Studio で Gradle Sync を行ってください。
 
-### 3. ビルド確認
+### 3. GitHub ラベルのセットアップ (推奨)
+Release Drafter が正しく動作するために必要なラベル（major, minor, patch 等）を一括登録します。
+
+```bash
+# Bash (macOS/Linux)
+chmod +x scripts/setup-labels.sh
+./scripts/setup-labels.sh
+
+# PowerShell (Windows)
+./scripts/setup-labels.ps1
+```
+
+### 4. ビルド確認
 ```bash
 ./gradlew assembleDebug
 ```
 
-### 4. アシスタントとの開発サイクル（推奨）
+### 5. アシスタントとの開発サイクル（推奨）
 Antigravity を使用している場合は、以下のフローで役割を分担しながら開発を進めることを推奨します。
 
 | ステップ | アクション | 担当 | 備考 |

--- a/docs/progress/task.md
+++ b/docs/progress/task.md
@@ -49,4 +49,7 @@
 - [x] Git 操作ルールの見直し（読み取り専用コマンドの自動実行許可）[#74](https://github.com/asabon/AndroidAppTemplate/issues/74)
 - [x] GitHub 操作ルールの導入とワークフローの強化（テンプレート活用）
 - [x] 検証ルールの `coding.md` への統合と視認性向上
-- [x] タスク・Issue管理フローの再定義 (`task_management.md`) とブランチ・PR運用の明文化
+- [x] タスク・Issue管理フローの再定義 (`task_management.md`) とブランチ・PR運用の明文化 [#78](https://github.com/asabon/AndroidAppTemplate/issues/78)
+
+## フェーズ 6: 運用支援ツールの拡充 [/]
+- [x] Release Drafter 用 GitHub Labels セットアップスクリプトの作成 (.sh, .ps1) [#80](https://github.com/asabon/AndroidAppTemplate/issues/80)

--- a/scripts/setup-labels.ps1
+++ b/scripts/setup-labels.ps1
@@ -1,0 +1,39 @@
+# Release Drafter 用の GitHub ラベルをセットアップするスクリプト
+# 各ラベルが既に存在してもエラーにならないように制御します。
+
+$ErrorActionPreference = "Stop"
+
+# ラベル定義
+$labels = @(
+    @{ name = "major"; color = "FF5733"; description = "主要なバージョンアップ（破壊的変更）" }
+    @{ name = "breaking"; color = "FF5733"; description = "破壊的変更" }
+    @{ name = "minor"; color = "33FF57"; description = "機能追加（マイナーバージョンアップ）" }
+    @{ name = "patch"; color = "3357FF"; description = "不具合修正・改善（パッチバージョンアップ）" }
+    @{ name = "feature"; color = "a2eeef"; description = "新機能" }
+    @{ name = "enhancement"; color = "a2eeef"; description = "機能改善" }
+    @{ name = "fix"; color = "d73a4a"; description = "不具合修正" }
+    @{ name = "bug"; color = "d73a4a"; description = "不具合報告" }
+    @{ name = "chore"; color = "c5def5"; description = "雑務・ビルド関連" }
+    @{ name = "documentation"; color = "0075ca"; description = "ドキュメント更新" }
+    @{ name = "maintenance"; color = "fbca04"; description = "メンテナンス" }
+    @{ name = "refactor"; color = "1d76db"; description = "リファクタリング" }
+    @{ name = "style"; color = "c2e0c4"; description = "コードスタイル" }
+    @{ name = "test"; color = "006b75"; description = "テスト追加・修正" }
+)
+
+Write-Host "Checking and creating GitHub Labels for Release Drafter..." -ForegroundColor Cyan
+
+foreach ($label in $labels) {
+    $existing = gh label list --search $label.name | Where-Object { $_ -match "\b$($label.name)\b" }
+    
+    if ($existing) {
+        Write-Host "Label '$($label.name)' already exists. Updating..." -ForegroundColor Yellow
+        gh label edit $label.name --color $label.color --description $label.description
+    }
+    else {
+        Write-Host "Creating label '$($label.name)'..." -ForegroundColor Green
+        gh label create $label.name --color $label.color --description $label.description
+    }
+}
+
+Write-Host "Labels setup completed!" -ForegroundColor Cyan

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Release Drafter 用の GitHub ラベルをセットアップするスクリプト
+# 各ラベルが既に存在してもエラーにならないように制御します。
+
+set -e
+
+# ラベル定義: "名前:カラー:説明"
+LABELS=(
+  "major:FF5733:主要なバージョンアップ（破壊的変更）"
+  "breaking:FF5733:破壊的変更"
+  "minor:33FF57:機能追加（マイナーバージョンアップ）"
+  "patch:3357FF:不具合修正・改善（パッチバージョンアップ）"
+  "feature:a2eeef:新機能"
+  "enhancement:a2eeef:機能改善"
+  "fix:d73a4a:不具合修正"
+  "bug:d73a4a:不具合報告"
+  "chore:c5def5:雑務・ビルド関連"
+  "documentation:0075ca:ドキュメント更新"
+  "maintenance:fbca04:メンテナンス"
+  "refactor:1d76db:リファクタリング"
+  "style:c2e0c4:コードスタイル"
+  "test:006b75:テスト追加・修正"
+)
+
+echo "Checking and creating GitHub Labels for Release Drafter..."
+
+for label_info in "${LABELS[@]}"; do
+  IFS=':' read -r name color description <<< "$label_info"
+  
+  if gh label list --search "$name" | grep -q -w "$name"; then
+    echo "Label '$name' already exists. Updating..."
+    gh label edit "$name" --color "$color" --description "$description"
+  else
+    echo "Creating label '$name'..."
+    gh label create "$name" --color "$color" --description "$description"
+  fi
+done
+
+echo "Labels setup completed!"


### PR DESCRIPTION
## 概要
Release Drafter の自動化フローを円滑に開始するため、必要となる GitHub ラベル（major, minor, feature 等）を一括で登録・更新するスクリプトを追加しました。

## 変更内容
- **新スクリプトの追加**:
  - \scripts/setup-labels.sh\: macOS/Linux 用の Bash スクリプト
  - \scripts/setup-labels.ps1\: Windows 用の PowerShell スクリプト
- **README.md の更新**:
  - 初期セットアップ手順に「GitHub ラベルのセットアップ」セクションを追加。
  - 手順番号を整理。

Closes #80