### PR TITLE
テンプレート説明用 README の分離

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,127 +1,59 @@
 [![build](https://github.com/asabon/AndroidAppTemplate/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/asabon/AndroidAppTemplate/actions/workflows/build.yml)
 
-# AndroidAppTemplate
+# [Your App Name]
+
+> [!TIP]
+> **テンプレートの利用方法について**
+> このリポジトリ自体のセットアップ方法や使い方については、[docs/TEMPLATE_USAGE.md](docs/TEMPLATE_USAGE.md) を参照してください。
 
 ## 概要
 
-このリポジトリは、Android アプリ開発を開始する際の **GitHub リポジトリテンプレート** です。
-あらかじめ最適な CI/CD 環境が組み込まれており、さらに AI アシスタント（Antigravity）を利用している開発者向けの便利な設定も統合されています。
+[アプリの簡単な説明をここに記述してください]
 
-## 主な特徴
+## 主な機能
 
-- **CI/CD 標準装備**: Lint チェック、ユニットテスト、ビルドチェックが設定済み。
-- **品質管理**: Ktlint, Android Lint によるコード品質の維持が容易です。
-- **AI アシスタント対応**: Antigravity 向けの設定が同梱されており、利用する場合は AI とスムーズに連携して開発を進められます。
+- 機能 1
+- 機能 2
+- 機能 3
 
----
-
-## クイックスタート
-
-### 1. リポジトリの作成
-GitHub の **"Use this template"** ボタンをクリックし、新しいリポジトリを作成します。
-
-### 2. 初期セットアップ
-ローカルにクローンした後、付属のスクリプトを使用してプロジェクト名とパッケージ名を一括置換します。
-
-**Windows (PowerShell):**
-```powershell
-./scripts/rename-project.ps1 -NewProjectName "MyNewApp" -NewPackageName "com.myself.myapp"
-```
-
-**Mac / Linux / Git Bash:**
-```bash
-chmod +x scripts/rename-project.sh
-./scripts/rename-project.sh "MyNewApp" "com.myself.myapp"
-```
-
-実行後、Android Studio で Gradle Sync を行ってください。
-
-### 3. GitHub ラベルのセットアップ (推奨)
-Release Drafter が正しく動作するために必要なラベル（major, minor, patch 等）を一括登録します。
+## 開発環境のセットアップ
 
 ```bash
-# Bash (macOS/Linux)
-chmod +x scripts/setup-labels.sh
-./scripts/setup-labels.sh
+# クローン
+git clone [repository-url]
+cd [repository-name]
 
-# PowerShell (Windows)
-./scripts/setup-labels.ps1
-```
-
-### 4. ビルド確認
-```bash
+# ビルド確認
 ./gradlew assembleDebug
 ```
 
-### 5. アシスタントとの開発サイクル（推奨）
-Antigravity を使用している場合は、以下のフローで役割を分担しながら開発を進めることを推奨します。
+## アーキテクチャ
 
-| ステップ | アクション | 担当 | 備考 |
-| :--- | :--- | :--- | :--- |
-| **1. 開始** | `/init` または `/resume` を実行 | **ユーザー** | 初回は `/init`、2回目以降は `/resume` |
-| **2. 計画** | 要望を伝えて `task.md` と Issue を作成 | ユーザー / **AI** | `/issue_new` 相当 |
-| **3. 準備** | 作業用ブランチ（`[Issue番号]-名前`）を作成しチェックアウト | **AI** | `gh issue develop` |
-| **4. 実装** | 実装と検証（ビルド・Lint）を行う | **AI** | `coding.md` 遵守 |
-| **5. 報告** | `task.md` を完了にし、進捗を保存して報告 | **AI** | |
-| **6. 確認** | 内容を確認し **コミット・プッシュ** | **ユーザー** | `task.md` の完了も同時に push |
-| **7. 申請** | **プルリクエスト (PR)** を作成 | **AI** | `/complete` ワークフロー開始 |
-| **8. 承認** | PR を確認し **マージ** | **ユーザー** | |
-| **9. 整理** | **後片付け** (ブランチ削除等) | **AI** (Navi) | `main` へ復帰 |
+このプロジェクトは Android 推奨の最新アーキテクチャに基づいています。
 
-- **セッション管理 (いずれか一方を開始時に実行)**:
-  - `/init`: プロジェクトルールの初回読み込み（新しいチャットセッションの開始時）。
-  - `/resume`: 前回中断した作業の再開（2回目以降のプロジェクト開始時。**`/init` は不要**です）。
-- **開発サイクル支援 (主に AI が状況に応じて実行する)**:
-  - `/save`: 現在の状態を `task.md` に保存（Step 5 等で AI が自動実行）。
-  - `/complete`: PR 作成からマージ後の整理までをナビゲート（Step 7-9 で AI が使用）。
-  - `/issue_new` / `/issue_comment`: GitHub Issue の起票や更新。
-
----
+- **UI**: Jetpack Compose
+- **DI**: Hilt
+- **Async**: Coroutines / Flow
+- **Architecture**: MVVM + Repository Pattern
 
 ## ディレクトリ構成
 
 ```text
-+ .agent/
-  + rules/          # 開発、Git、GitHub、タスク管理の詳細ルール
-  + workflows/      # AI アシスタント用コマンド（/init, /save 等）
-+ .github/
-  + workflows/      # CI/CD ワークフロー定義 (GitHub Actions)
-+ app/              # Android アプリ本体
-+ ci/               # CI/CD 各種ツールの詳細設定・ドキュメント
-+ docs/
-  + progress/
-    + task.md       # 進捗管理（唯一の真実：Source of Truth）
++ app/
+  + src/main/java/
+    + data/           # Repository, DataSource, API
+    + di/             # Hilt Modules
+    + domain/         # UseCases, Model (Optional)
+    + ui/             # Screens, ViewModels, Components
 ```
 
----
+## テスト
 
-## CI/CD ワークフロー詳細
+```bash
+# ユニットテスト
+./gradlew testDebugUnitTest
 
-以下のワークフローが自動で実行され、プロジェクトの品質維持とリリースフローを支えます。
-
-### 品質管理・検証（Pull Request / Push 時）
-- **[Build](https://github.com/asabon/AndroidAppTemplate/actions/workflows/build.yml)**: `assembleRelease` のビルド確認。PR 時には Danger による自動報告を行います。
-- **[Unit Test](https://github.com/asabon/AndroidAppTemplate/actions/workflows/unitTest.yml)**: ユニットテストの実行。テストレポートとカバレッジ（Kover）を生成します。
-- **[Ktlint](https://github.com/asabon/AndroidAppTemplate/actions/workflows/ktlint.yml)**: Kotlin のコーディング規約（Ktlint）のチェックを行います。
-- **[Android Lint](https://github.com/asabon/AndroidAppTemplate/actions/workflows/androidLint.yml)**: Android 特有のコード品質や潜在的なバグ（Android Lint）をチェックします。
-
-### リリースプロセス
-- **[Release Drafter](https://github.com/asabon/AndroidAppTemplate/actions/workflows/release-drafter.yml)**: マージされた PR のラベルに基づき、リリースノートのドラフトを自動生成します。
-- **[Bump Version](https://github.com/asabon/AndroidAppTemplate/actions/workflows/bump-version.yml)**: ドラフトされたバージョンを `version.properties` に反映するための PR を作成します。
-- **[Build Signed AAB](https://github.com/asabon/AndroidAppTemplate/actions/workflows/build-aab.yml)**: `v*` タグの Push 時に、署名済み AAB をビルドし、GitHub Release へ自動アップロードします。
-
----
-
-## 開発・リリース運用について
-
-詳細なバージョン管理ルールやリリースの手順については [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。
-
----
-
-## カスタマイズ方法
-
-### パッケージ名の変更
-`app/build.gradle.kts` の `namespace` および `applicationId` を変更し、ソースコードのディレクトリ構造をそれに合わせて移動してください。
-
-### GitHub Secrets の設定
-自動配信（AAB生成など）を行う場合は、GitHub リポジトリの Secrets に必要なキーを登録してください。
+# Lint チェック
+./gradlew ktlintCheck
+./gradlew lintDebug
+```

--- a/docs/TEMPLATE_USAGE.md
+++ b/docs/TEMPLATE_USAGE.md
@@ -1,0 +1,127 @@
+[![build](https://github.com/asabon/AndroidAppTemplate/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/asabon/AndroidAppTemplate/actions/workflows/build.yml)
+
+# AndroidAppTemplate
+
+## 概要
+
+このリポジトリは、Android アプリ開発を開始する際の **GitHub リポジトリテンプレート** です。
+あらかじめ最適な CI/CD 環境が組み込まれており、さらに AI アシスタント（Antigravity）を利用している開発者向けの便利な設定も統合されています。
+
+## 主な特徴
+
+- **CI/CD 標準装備**: Lint チェック、ユニットテスト、ビルドチェックが設定済み。
+- **品質管理**: Ktlint, Android Lint によるコード品質の維持が容易です。
+- **AI アシスタント対応**: Antigravity 向けの設定が同梱されており、利用する場合は AI とスムーズに連携して開発を進められます。
+
+---
+
+## クイックスタート
+
+### 1. リポジトリの作成
+GitHub の **"Use this template"** ボタンをクリックし、新しいリポジトリを作成します。
+
+### 2. 初期セットアップ
+ローカルにクローンした後、付属のスクリプトを使用してプロジェクト名とパッケージ名を一括置換します。
+
+**Windows (PowerShell):**
+```powershell
+./scripts/rename-project.ps1 -NewProjectName "MyNewApp" -NewPackageName "com.myself.myapp"
+```
+
+**Mac / Linux / Git Bash:**
+```bash
+chmod +x scripts/rename-project.sh
+./scripts/rename-project.sh "MyNewApp" "com.myself.myapp"
+```
+
+実行後、Android Studio で Gradle Sync を行ってください。
+
+### 3. GitHub ラベルのセットアップ (推奨)
+Release Drafter が正しく動作するために必要なラベル（major, minor, patch 等）を一括登録します。
+
+```bash
+# Bash (macOS/Linux)
+chmod +x scripts/setup-labels.sh
+./scripts/setup-labels.sh
+
+# PowerShell (Windows)
+./scripts/setup-labels.ps1
+```
+
+### 4. ビルド確認
+```bash
+./gradlew assembleDebug
+```
+
+### 5. アシスタントとの開発サイクル（推奨）
+Antigravity を使用している場合は、以下のフローで役割を分担しながら開発を進めることを推奨します。
+
+| ステップ | アクション | 担当 | 備考 |
+| :--- | :--- | :--- | :--- |
+| **1. 開始** | `/init` または `/resume` を実行 | **ユーザー** | 初回は `/init`、2回目以降は `/resume` |
+| **2. 計画** | 要望を伝えて `task.md` と Issue を作成 | ユーザー / **AI** | `/issue_new` 相当 |
+| **3. 準備** | 作業用ブランチ（`[Issue番号]-名前`）を作成しチェックアウト | **AI** | `gh issue develop` |
+| **4. 実装** | 実装と検証（ビルド・Lint）を行う | **AI** | `coding.md` 遵守 |
+| **5. 報告** | `task.md` を完了にし、進捗を保存して報告 | **AI** | |
+| **6. 確認** | 内容を確認し **コミット・プッシュ** | **ユーザー** | `task.md` の完了も同時に push |
+| **7. 申請** | **プルリクエスト (PR)** を作成 | **AI** | `/complete` ワークフロー開始 |
+| **8. 承認** | PR を確認し **マージ** | **ユーザー** | |
+| **9. 整理** | **後片付け** (ブランチ削除等) | **AI** (Navi) | `main` へ復帰 |
+
+- **セッション管理 (いずれか一方を開始時に実行)**:
+  - `/init`: プロジェクトルールの初回読み込み（新しいチャットセッションの開始時）。
+  - `/resume`: 前回中断した作業の再開（2回目以降のプロジェクト開始時。**`/init` は不要**です）。
+- **開発サイクル支援 (主に AI が状況に応じて実行する)**:
+  - `/save`: 現在の状態を `task.md` に保存（Step 5 等で AI が自動実行）。
+  - `/complete`: PR 作成からマージ後の整理までをナビゲート（Step 7-9 で AI が使用）。
+  - `/issue_new` / `/issue_comment`: GitHub Issue の起票や更新。
+
+---
+
+## ディレクトリ構成
+
+```text
++ .agent/
+  + rules/          # 開発、Git、GitHub、タスク管理の詳細ルール
+  + workflows/      # AI アシスタント用コマンド（/init, /save 等）
++ .github/
+  + workflows/      # CI/CD ワークフロー定義 (GitHub Actions)
++ app/              # Android アプリ本体
++ ci/               # CI/CD 各種ツールの詳細設定・ドキュメント
++ docs/
+  + progress/
+    + task.md       # 進捗管理（唯一の真実：Source of Truth）
+```
+
+---
+
+## CI/CD ワークフロー詳細
+
+以下のワークフローが自動で実行され、プロジェクトの品質維持とリリースフローを支えます。
+
+### 品質管理・検証（Pull Request / Push 時）
+- **[Build](https://github.com/asabon/AndroidAppTemplate/actions/workflows/build.yml)**: `assembleRelease` のビルド確認。PR 時には Danger による自動報告を行います。
+- **[Unit Test](https://github.com/asabon/AndroidAppTemplate/actions/workflows/unitTest.yml)**: ユニットテストの実行。テストレポートとカバレッジ（Kover）を生成します。
+- **[Ktlint](https://github.com/asabon/AndroidAppTemplate/actions/workflows/ktlint.yml)**: Kotlin のコーディング規約（Ktlint）のチェックを行います。
+- **[Android Lint](https://github.com/asabon/AndroidAppTemplate/actions/workflows/androidLint.yml)**: Android 特有のコード品質や潜在的なバグ（Android Lint）をチェックします。
+
+### リリースプロセス
+- **[Release Drafter](https://github.com/asabon/AndroidAppTemplate/actions/workflows/release-drafter.yml)**: マージされた PR のラベルに基づき、リリースノートのドラフトを自動生成します。
+- **[Bump Version](https://github.com/asabon/AndroidAppTemplate/actions/workflows/bump-version.yml)**: ドラフトされたバージョンを `version.properties` に反映するための PR を作成します。
+- **[Build Signed AAB](https://github.com/asabon/AndroidAppTemplate/actions/workflows/build-aab.yml)**: `v*` タグの Push 時に、署名済み AAB をビルドし、GitHub Release へ自動アップロードします。
+
+---
+
+## 開発・リリース運用について
+
+詳細なバージョン管理ルールやリリースの手順については [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。
+
+---
+
+## カスタマイズ方法
+
+### パッケージ名の変更
+`app/build.gradle.kts` の `namespace` および `applicationId` を変更し、ソースコードのディレクトリ構造をそれに合わせて移動してください。
+
+### GitHub Secrets の設定
+自動配信（AAB生成など）を行う場合は、GitHub リポジトリの Secrets に必要なキーを登録してください。

--- a/docs/progress/task.md
+++ b/docs/progress/task.md
@@ -57,8 +57,11 @@
 - [x] セッション完了フロー（task.md更新タイミング、ブランチ削除）の最適化 [#82](https://github.com/asabon/AndroidAppTemplate/issues/82)
 - [x] `/save` ワークフローへの「栞（Checkpoint）」機能の導入 [#84](https://github.com/asabon/AndroidAppTemplate/issues/84)
 
-- **Checkpoint: 2025-12-27 (中断)**
-    - 状況: 実装完了、Step 6（プッシュ待ち）。
-    - 具体的次の一手: ユーザー様のプッシュを待ち、確認後に \/complete\ で PR 作成 (Step 7) を行う。
+- **Checkpoint: 2025-12-28 (完了)**
+    - 状況: Issue #86 (Git/GitHub操作ルールの更新) を完了し、PR #87 をマージしました。タスク進捗ファイル (`task.md`) 上の全フェーズは完了状態です。
+    - 具体的次の一手: 新しい改善要望または機能開発の指示待ち。
+
+## フェーズ 7: ユーザビリティ向上 [/]
+- [x] テンプレート説明用 README の分離 (README.md -> docs/TEMPLATE_USAGE.md)
 
 


### PR DESCRIPTION
## 概要
テンプレートの使用方法を \docs/TEMPLATE_USAGE.md\ に分離し、アプリ開発用の標準的な README テンプレートを配置しました。

## 関連 Issue
Close #88